### PR TITLE
travis: Deploy packages to BinTray for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,19 @@ env:
 
 install: beaver dlang install
 
-script: BEAVER_DOCKER_VARS="F" beaver dlang make
+# Build packages too, this should be done by beaver:
+# https://github.com/sociomantic-tsunami/beaver/issues/34
+script: BEAVER_DOCKER_VARS="F" beaver dlang make && beaver dlang make pkg
+
+jobs:
+    include:
+        - stage: Upload Package
+          # We need to include the exclusion of D2 tags because this "if"
+          # replaces the global one
+          if: tag IS present
+          # Which package to deploy
+          env: DMD=dmd1 DIST=xenial F=production
+          # before_install: and install: are inherited and we don't need to
+          # override them.
+          script: beaver bintray upload -d sociomantic-tsunami/nodes/dmqnode
+                  build/last/pkg/*.deb


### PR DESCRIPTION
When tags are built, packages will be created and uploaded to BinTray automatically (to https://bintray.com/sociomantic-tsunami/nodes/dmqnode).

DHT node commit: https://github.com/sociomantic-tsunami/dhtnode/pull/44/commits/8de577a3f94ba87b7efec1cbbfd35e0c315dfcc0