### PR TITLE
Use systemctl to reload all DMQ instances on log reload

### DIFF
--- a/deploy/logrotate/dmqnode-logs
+++ b/deploy/logrotate/dmqnode-logs
@@ -19,6 +19,6 @@
 	maxsize 500M
 	sharedscripts
 	postrotate
-		/usr/bin/killall -HUP dmqnode
+		systemctl reload 'dmq@*'
 	endscript
 }


### PR DESCRIPTION
/usr/bin/killall -HUP <name> has a problem where the name of the running
binary is overridden. This uses systemctl to reload all services.