### PR TITLE
Don't catch OutOfMemoryError

### DIFF
--- a/src/dmqnode/main.d
+++ b/src/dmqnode/main.d
@@ -28,7 +28,6 @@ import dmqproto.client.legacy.DmqConst;
 
 import swarm.util.node.log.Stats;
 
-import ocean.core.ExceptionDefinitions : OutOfMemoryException;
 import ocean.core.MessageFiber;
 import ocean.io.select.client.model.ISelectClient;
 import ocean.io.select.EpollSelectDispatcher;
@@ -241,10 +240,6 @@ public class DmqNodeServer : DaemonApp
         {
             // Don't log these exception types, which only occur on the normal
             // disconnection of a client.
-        }
-        else if ( cast(OutOfMemoryException)exception )
-        {
-            log.error("OutOfMemoryException caught in eventLoop");
         }
         else
         {


### PR DESCRIPTION
In D2 this is an `Error` rather than an `Exception`, so catching it is undefined behaviour.  In any case, in an OOM situation it is unlikely that logging a special message will help much (cf. similar changes in dhtnode and dlsnode codebases).

The `OutOfMemoryException` alias has in any case been dropped in ocean v5.x.x, so dropping this check removes one blocker to upgrading.