### PR TITLE
pkg: Add after install script for dmqnode package

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -31,7 +31,8 @@ allunittest: override LDFLAGS += -lpcre
 #$O/%unittests: override LDFLAGS += 
 
 # Package dependencies
-$O/pkg-dmqnode.stamp: $B/dmqnode README.rst
+$O/pkg-dmqnode.stamp: $B/dmqnode README.rst \
+	$(PKG)/after_dmqnode_install.sh
 
 $O/pkg-dmqnode-common.stamp: \
        $(PKG)/defaults.py README.rst

--- a/pkg/after_dmqnode_install.sh
+++ b/pkg/after_dmqnode_install.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# Exits with an error message
+error_exit()
+{
+    msg="$1"
+    code="$2"
+    echo "$msg" 1>&2
+    exit "$code"
+}
+
+APP="dmqnode"
+
+if [ "$1" = "configure" ]; then
+    adduser --system --group --no-create-home ${APP}
+
+    # Check that deployment directory exists
+    test -d /srv/dmqnode/dmqnode-* || error_exit "/srv/dmqnode/dmqnode-* directories missing" 1
+
+    # Create directory structure if missing and ensure proper permissions.
+    for FOLDER in $(find /srv/dmqnode -type d -name "dmqnode-[0-9]*")
+    do
+        install --owner=${APP} --group=${APP} -d $FOLDER/data
+        install --owner=${APP} --group=${APP} -d $FOLDER/etc
+        # Only the user should be able to write to the log directory,
+        # otherwise logrotate will complain...
+        install --owner=${APP} --group=${APP} --mode="u=rwx,g=rx,o=rx" -d $FOLDER/log
+    done
+fi

--- a/pkg/dmqnode.pkg
+++ b/pkg/dmqnode.pkg
@@ -6,6 +6,7 @@ OPTS.update(
     description = FUN.desc(epilog='''\
 The DMQ node is a server implementing one node for a network message queue.'''),
     provides = 'dmqnode',
+    after_install = 'pkg/after_dmqnode_install.sh',
     depends = FUN.autodeps(bins, path=VAR.bindir),
     deb_recommends = 'dmqnode-common',
 )


### PR DESCRIPTION
The after install script will create the dmqnode user if it
does not exist and ensure each instance has the right directory
structure and the proper permissions are set.