### PR TITLE
Replace uses of deprecated getMsg method with Exception.message

### DIFF
--- a/integrationtest/ovfminimize/main.d
+++ b/integrationtest/ovfminimize/main.d
@@ -30,7 +30,6 @@ import core.sys.posix.stdlib: srand48, mrand48;
 import core.sys.posix.sys.stat: stat_t, fstat;
 import core.stdc.stdio: SEEK_CUR;
 import core.stdc.stdlib: EXIT_SUCCESS, EXIT_FAILURE;
-import ocean.transition: getMsg;
 import ocean.util.log.Logger;
 
 /*******************************************************************************
@@ -57,7 +56,7 @@ int main ( )
     catch (Exception e)
     {
         Log.lookup("test-ovfminimize").error(
-            "{} @{}:{}", getMsg(e), e.file, e.line
+            "{} @{}:{}", e.message, e.file, e.line
         );
         return EXIT_FAILURE;
     }

--- a/src/dmqnode/main.d
+++ b/src/dmqnode/main.d
@@ -244,7 +244,7 @@ public class DmqNodeServer : DaemonApp
         else
         {
             log.error("Exception caught in eventLoop: '{}' @ {}:{}",
-                    getMsg(exception), exception.file, exception.line);
+                      exception.message, exception.file, exception.line);
         }
     }
 

--- a/src/dmqnode/storage/engine/DiskOverflow.d
+++ b/src/dmqnode/storage/engine/DiskOverflow.d
@@ -469,7 +469,7 @@ class DiskOverflow: DiskOverflowInfo
         }
         catch (FileException e)
         {
-            log.error("Error testing file truncation: {}", getMsg(e));
+            log.error("Error testing file truncation: {}", e.message);
         }
 
         this.e     = new DiskOverflowException;

--- a/src/dmqnode/storage/engine/overflow/file/HeadTruncationTestFile.d
+++ b/src/dmqnode/storage/engine/overflow/file/HeadTruncationTestFile.d
@@ -66,7 +66,7 @@ class HeadTruncationTestFile: DataFile
             this.head_truncation_supported = (filesize == 100);
         }
         catch (FileException e)
-            this.log.error(getMsg(e));
+            this.log.error(e.message);
 
         this.remove();
     }


### PR DESCRIPTION
This has been deprecated since the ocean v3.9.0/v4.2.0 releases, and it will be a blocker to upgrading to ocean v5.x.x.