### PR TITLE
Replace all remaining imports of ocean.transition

### DIFF
--- a/integrationtest/dmqtest/main.d
+++ b/integrationtest/dmqtest/main.d
@@ -16,9 +16,9 @@ module integrationtest.dmqtest.main;
 
 
 import dmqtest.TestRunner;
+import ocean.meta.types.Qualifiers : istring;
 import turtle.runner.Runner;
 
-import ocean.transition;
 
 /*******************************************************************************
 

--- a/integrationtest/loadfiles/cases/LoadFiles.d
+++ b/integrationtest/loadfiles/cases/LoadFiles.d
@@ -47,8 +47,9 @@ class LoadFiles: TestCase
     import ocean.task.Scheduler;
     import ocean.task.Task;
     import Test = ocean.core.Test;
+    import ocean.core.TypeConvert : assumeUnique;
+    import ocean.meta.types.Qualifiers : cstring, istring, mstring;
     import ocean.util.log.Logger;
-    import ocean.transition;
 
     /***************************************************************************
 

--- a/integrationtest/loadfiles/cases/checker/CheckedRequests.d
+++ b/integrationtest/loadfiles/cases/checker/CheckedRequests.d
@@ -17,7 +17,8 @@ module integrationtest.loadfiles.cases.checker.CheckedRequests;
 import dmqproto.client.DmqClient;
 import ocean.task.Task;
 import ocean.core.Traits;
-import ocean.transition;
+import ocean.core.TypeConvert : assumeUnique;
+import ocean.meta.types.Qualifiers : Const, cstring, Immut, istring;
 
 /*******************************************************************************
 

--- a/integrationtest/loadfiles/main.d
+++ b/integrationtest/loadfiles/main.d
@@ -14,8 +14,8 @@ module integrationtest.loadfiles.main;
 
 import integrationtest.loadfiles.cases.LoadFiles;
 import turtle.runner.Runner;
+import ocean.meta.types.Qualifiers : istring;
 import ocean.util.log.Logger;
-import ocean.transition;
 
 /*******************************************************************************
 

--- a/src/dmqnode/config/ChannelSizeConfig.d
+++ b/src/dmqnode/config/ChannelSizeConfig.d
@@ -19,7 +19,7 @@ public struct ChannelSizeConfig
     import ocean.core.Enforce;
     import ocean.core.ExceptionDefinitions: IllegalArgumentException;
     import ocean.math.Math: min;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers : cstring, istring;
 
     /***************************************************************************
 

--- a/src/dmqnode/config/ServerConfig.d
+++ b/src/dmqnode/config/ServerConfig.d
@@ -15,7 +15,6 @@ module dmqnode.config.ServerConfig;
 
 import ConfigReader = ocean.util.config.ConfigFiller;
 
-import ocean.transition;
 
 /*******************************************************************************
 
@@ -25,6 +24,8 @@ import ocean.transition;
 
 public class ServerConfig
 {
+    import ocean.meta.types.Qualifiers : istring;
+
     ConfigReader.Required!(char[]) address;
 
     ConfigReader.Required!(ushort) port;

--- a/src/dmqnode/connection/neo/SharedResources.d
+++ b/src/dmqnode/connection/neo/SharedResources.d
@@ -140,7 +140,7 @@ public final class SharedResources
                 auto buffer =
                     this.outer.value_buffers.get(cast(ubyte[])new void[len]);
                 buffer.length = 0;
-                enableStomping(buffer);
+                assumeSafeAppend(buffer);
 
                 return buffer;
             }

--- a/src/dmqnode/connection/neo/SharedResources.d
+++ b/src/dmqnode/connection/neo/SharedResources.d
@@ -13,7 +13,6 @@
 
 module dmqnode.connection.neo.SharedResources;
 
-import ocean.transition;
 
 /*******************************************************************************
 

--- a/src/dmqnode/main.d
+++ b/src/dmqnode/main.d
@@ -33,14 +33,13 @@ import ocean.io.select.client.model.ISelectClient;
 import ocean.io.select.EpollSelectDispatcher;
 import ocean.io.select.protocol.generic.ErrnoIOException : IOWarning;
 import ocean.io.select.selector.EpollException;
+import ocean.meta.types.Qualifiers : istring;
 import core.sys.posix.signal: SIGINT, SIGTERM, SIGQUIT;
 import ocean.sys.CpuAffinity;
 import ocean.util.app.DaemonApp;
 import ConfigReader = ocean.util.config.ConfigFiller;
 import ocean.util.log.Logger;
-import ocean.transition;
 
-import ocean.transition;
 
 /*******************************************************************************
 

--- a/src/dmqnode/request/GetChannelsRequest.d
+++ b/src/dmqnode/request/GetChannelsRequest.d
@@ -17,8 +17,6 @@ import dmqnode.request.model.IDmqRequestResources;
 
 import Protocol = dmqproto.node.request.GetChannels;
 
-import ocean.transition;
-
 
 /*******************************************************************************
 

--- a/src/dmqnode/request/neo/Consume.d
+++ b/src/dmqnode/request/neo/Consume.d
@@ -22,8 +22,6 @@ import dmqnode.storage.model.StorageEngine;
 import ocean.core.TypeConvert : castFrom;
 import dmqnode.util.Downcast;
 
-import ocean.transition;
-
 
 /*******************************************************************************
 
@@ -33,6 +31,8 @@ import ocean.transition;
 
 class ConsumeImpl_v4 : ConsumeProtocol_v4, StorageEngine.IConsumer
 {
+    import ocean.meta.types.Qualifiers : cstring, mstring;
+
     /***************************************************************************
 
         Storage engine being consumed from.

--- a/src/dmqnode/request/neo/Pop.d
+++ b/src/dmqnode/request/neo/Pop.d
@@ -19,7 +19,6 @@ import dmqproto.node.neo.request.Pop;
 import dmqproto.node.neo.request.core.IRequestResources;
 
 import dmqnode.util.Downcast;
-import ocean.transition;
 
 /*******************************************************************************
 
@@ -30,6 +29,7 @@ import ocean.transition;
 class PopImpl_v1 : PopProtocol_v1
 {
     import ocean.core.TypeConvert : castFrom, downcast;
+    import ocean.meta.types.Qualifiers : cstring, mstring;
 
     /***************************************************************************
 

--- a/src/dmqnode/request/neo/Push.d
+++ b/src/dmqnode/request/neo/Push.d
@@ -17,7 +17,6 @@ import dmqproto.node.neo.request.Push;
 import dmqproto.node.neo.request.core.IRequestResources;
 
 import dmqnode.util.Downcast;
-import ocean.transition;
 
 /*******************************************************************************
 
@@ -28,6 +27,7 @@ import ocean.transition;
 class PushImpl_v3 : PushProtocol_v3
 {
     import ocean.core.TypeConvert : castFrom;
+    import ocean.meta.types.Qualifiers : Const, cstring;
 
     /***************************************************************************
 

--- a/src/dmqnode/storage/Ring.d
+++ b/src/dmqnode/storage/Ring.d
@@ -36,7 +36,6 @@ import ocean.util.container.queue.FlexibleRingQueue;
 import ocean.util.container.queue.model.IQueueInfo;
 import ocean.util.log.Logger;
 import core.stdc.ctype;
-import ocean.transition;
 
 
 /*******************************************************************************
@@ -62,6 +61,8 @@ static this ( )
 
 public class RingNode : StorageChannels
 {
+    import ocean.meta.types.Qualifiers : Const, cstring, Immut, istring;
+
     /***************************************************************************
 
         Dump file name suffix

--- a/src/dmqnode/storage/Ring.d
+++ b/src/dmqnode/storage/Ring.d
@@ -318,7 +318,7 @@ public class RingNode : StorageChannels
             scope allocValue = delegate void[] ( size_t n )
             {
                 if (value.length < n)
-                    enableStomping(value);
+                    assumeSafeAppend(value);
 
                 value.length = n;
                 return value;

--- a/src/dmqnode/storage/engine/DiskOverflow.d
+++ b/src/dmqnode/storage/engine/DiskOverflow.d
@@ -219,7 +219,7 @@ class DiskOverflow: DiskOverflowInfo
     import core.sys.posix.sys.types: off_t;
     import core.stdc.stdio: SEEK_CUR, SEEK_END;
     import ocean.core.Verify;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers : cstring, istring, Unqual;
     import ocean.util.log.Logger;
 
     /***************************************************************************

--- a/src/dmqnode/storage/engine/OverflowChannel.d
+++ b/src/dmqnode/storage/engine/OverflowChannel.d
@@ -17,10 +17,10 @@ import dmqnode.storage.engine.DiskOverflow;
 import dmqnode.storage.engine.overflow.ChannelMetadata;
 import dmqnode.storage.engine.overflow.RecordHeader;
 
-import ocean.transition;
-
 package class OverflowChannel: DiskOverflowInfo
 {
+    import ocean.meta.types.Qualifiers : istring;
+
     /***************************************************************************
 
         The channel name.

--- a/src/dmqnode/storage/engine/overflow/ChannelMetadata.d
+++ b/src/dmqnode/storage/engine/overflow/ChannelMetadata.d
@@ -14,7 +14,6 @@ module dmqnode.storage.engine.overflow.ChannelMetadata;
 
 import dmqnode.storage.engine.overflow.RecordHeader;
 
-import ocean.transition;
 
 struct ChannelMetadata
 {
@@ -22,6 +21,7 @@ struct ChannelMetadata
     import Tracker = dmqnode.storage.engine.overflow.FirstOffsetTracker;
 
     import ocean.core.Enforce: enforce;
+    import ocean.meta.types.Qualifiers : istring;
     import ocean.stdc.posix.sys.types: off_t;
 
     /***************************************************************************

--- a/src/dmqnode/storage/engine/overflow/Constants.d
+++ b/src/dmqnode/storage/engine/overflow/Constants.d
@@ -14,7 +14,7 @@ module dmqnode.storage.engine.overflow.Constants;
 
 struct Constants
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers : Immut, istring;
 
     /***************************************************************************
 

--- a/src/dmqnode/storage/engine/overflow/file/DataFile.d
+++ b/src/dmqnode/storage/engine/overflow/file/DataFile.d
@@ -43,7 +43,7 @@ class DataFile: PosixFile
     import unistd = core.sys.posix.unistd: read, write, pread, pwrite;
     import uio = core.sys.posix.sys.uio: iovec, writev;
     import ocean.core.Verify;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers : cstring, istring;
 
     /***************************************************************************
 
@@ -362,7 +362,7 @@ struct IoVec
 {
     import swarm.neo.protocol.socket.uio_const: iovec_const;
     import ocean.core.Verify;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers : Const;
 
     /***************************************************************************
 

--- a/src/dmqnode/storage/engine/overflow/file/FileException.d
+++ b/src/dmqnode/storage/engine/overflow/file/FileException.d
@@ -17,8 +17,8 @@ import ocean.sys.ErrnoException;
 
 class FileException: ErrnoException
 {
+    import ocean.meta.types.Qualifiers : Immut, istring;
     import ocean.stdc.string: memmove;
-    import ocean.transition;
 
     /***************************************************************************
 

--- a/src/dmqnode/storage/engine/overflow/file/HeadTruncationTestFile.d
+++ b/src/dmqnode/storage/engine/overflow/file/HeadTruncationTestFile.d
@@ -20,7 +20,7 @@ class HeadTruncationTestFile: DataFile
     import dmqnode.storage.engine.overflow.file.FileException;
     import core.sys.posix.stdlib: mkstemp;
     import core.stdc.stdio: SEEK_END;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers : cstring;
 
     /***************************************************************************
 

--- a/src/dmqnode/storage/engine/overflow/file/IndexFile.d
+++ b/src/dmqnode/storage/engine/overflow/file/IndexFile.d
@@ -24,8 +24,7 @@ module dmqnode.storage.engine.overflow.file.IndexFile;
 
 import dmqnode.storage.engine.overflow.ChannelMetadata;
 import dmqnode.storage.engine.overflow.file.PosixFile;
-
-import ocean.transition;
+import ocean.meta.types.Qualifiers : cstring, istring;
 
 version (D_Version2)
     mixin(`
@@ -376,6 +375,7 @@ version (UnitTest)
     import core.stdc.stdio;
     import core.stdc.stdlib;
     import ocean.core.Test;
+    import ocean.meta.types.Qualifiers : Const;
     import ocean.sys.ErrnoException;
     extern (C) private FILE* fmemopen(void* buf, size_t size, Const!(char)* mode);
 

--- a/src/dmqnode/storage/engine/overflow/file/PosixFile.d
+++ b/src/dmqnode/storage/engine/overflow/file/PosixFile.d
@@ -26,8 +26,9 @@ class PosixFile
     import unistd = core.sys.posix.unistd: close, unlink;
     import core.sys.posix.unistd: lseek, ftruncate, fdatasync;
     import core.stdc.stdio: SEEK_SET;
+    import ocean.core.TypeConvert : assumeUnique;
     import ocean.core.Verify;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers : cstring, Immut, istring, mstring;
     import ocean.util.log.Logger;
 
     /***************************************************************************

--- a/src/dmqnode/storage/model/StorageChannels.d
+++ b/src/dmqnode/storage/model/StorageChannels.d
@@ -17,10 +17,9 @@
 
 module dmqnode.storage.model.StorageChannels;
 
-
+import ocean.meta.types.Qualifiers : cstring, istring;
 import swarm.node.storage.model.IStorageEngine;
 
-import ocean.transition;
 
 /*******************************************************************************
 

--- a/src/dmqnode/storage/model/StorageEngine.d
+++ b/src/dmqnode/storage/model/StorageEngine.d
@@ -27,13 +27,14 @@ import ocean.io.FilePath;
 import ocean.io.Path : normalize, PathParser;
 import ocean.sys.Environment;
 import ocean.core.Verify;
-import ocean.transition;
 
 import swarm.node.storage.listeners.Listeners;
 import swarm.node.storage.model.IStorageEngine;
 
 public abstract class StorageEngine : IStorageEngine
 {
+    import ocean.meta.types.Qualifiers : cstring;
+
     /***************************************************************************
 
         Set of consumers waiting for data on this storage channel. When data

--- a/src/dmqperformance/main.d
+++ b/src/dmqperformance/main.d
@@ -31,12 +31,11 @@ import dmqproto.client.legacy.DmqConst;
 import ocean.io.select.EpollSelectDispatcher;
 import ocean.io.Stdout;
 import ocean.math.SlidingAverage;
+import ocean.meta.types.Qualifiers : istring;
 import ocean.text.Arguments;
 import ocean.time.StopWatch;
 import ocean.util.app.CliApp;
 import ocean.util.log.StaticTrace;
-
-import ocean.transition;
 
 
 /*******************************************************************************


### PR DESCRIPTION
With the D2 transition done we can replace all uses of this transitional module.  The first patch replaces all uses of `enableStomping` with `assumeSafeAppend`, while the second replaces all `ocean.transition` imports with imports from non-transitional modules:

  * `istring`, `cstring`, `mstring`, `Const`, `Immut`, and `Unqual` are now all imported from `ocean.meta.types.Qualifiers`

  * `assumeUnique` is now imported from `ocean.core.TypeConvert`

In a few cases the `ocean.transition` import appears to not be used at all, in which case it has just been deleted.