### PR TITLE
Remove dependency on implicitly public import in StorageChannels test

### DIFF
--- a/src/dmqnode/storage/model/StorageChannels.d
+++ b/src/dmqnode/storage/model/StorageChannels.d
@@ -568,7 +568,7 @@ version (UnitTest)
 
 unittest
 {
-    static class Storage: IChannel.StorageEngine
+    static class Storage: StorageEngine
     {
         bool flushed, cleared, closed, recycled;
         uint records, bytes;


### PR DESCRIPTION
Basing the `Storage` test class on `IChannel.StorageEngine` relies on an assumption that importing `StorageEngine` inside `IChannel` exposes it publicly.  This will no longer be the case as of version 2.087.0 of the D frontend, so we need to use `StorageEngine` directly as the base class (note that the unittest will fail to build if this is not the same type as the internal storage engine of `IChannel`, so there was never a need to use `IChannel.StorageEngine` in the first place).