### PR TITLE
Add test builds with DMD 2.088.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,10 @@ jobs:
           env: DMD=2.078.* F=production
         - <<: *test-matrix
           env: DMD=2.078.* F=devel
+        - <<: *test-matrix
+          env: DMD=2.088.* F=production
+        - <<: *test-matrix
+          env: DMD=2.088.* F=devel
 
         # Test deployment docker image generation
         - stage: Test


### PR DESCRIPTION
This establishes that dmqnode can be built with the latest upstream DMD release, with no custom modifications.

No change has been made to production/deployment settings, but this will allow future code changes to be validated against the newest D frontend versions.  Note that this means that in principle dmqnode should also be able to build with other compilers (LDC or GDC) that use these supported frontend versions.

Note that the latest compiler versions (2.087 and 2.088) come with a lot of new deprecations, and remove a number of long deprecated features.  Most relevant to dmqnode are:

  * 2.087 deprecates the use of `scope` as a type constraint on class declarations:
    https://dlang.org/changelog/2.087.0.html#dep_scope_class

  * 2.087 ends the deprecation phase for access checks, which may have some impact on builds that rely on implicit imports:
    https://dlang.org/changelog/2.087.0.html#remove_visibility

  * 2.088 deprecates D1 operator overloads (e.g. `opNeg`, `opAdd`) in favour of `opUnary`, `opBinary`, etc.:
    https://dlang.org/changelog/2.088.0.html#dep_d1_ops

For dmqnode, most of the triggered deprecations appear to be in ocean, swarm and dmqproto rather than app code.