### PR TITLE
Add Build.mak variable to specify position-independent code

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -1,3 +1,9 @@
+# check whether to build with position-independent code
+# (may be required to build on newer distro releases)
+ifeq ($(USE_PIC), 1)
+	override DFLAGS += -fPIC
+endif
+
 ifeq ($F, production)
 	override DFLAGS += -release
 endif


### PR DESCRIPTION
Ubuntu 18.04 (among other distros) expects position-independent code.  The new `USE_PIC` build variable allows the user (or CI) to request this if the compiler does not use the `-fPIC` flag by default.