### PR TITLE
Update supported compiler matrix to match dhtnode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,29 +48,34 @@ jobs:
     include:
         # Test matrix
         - <<: *test-matrix
-          env: DMD=2.071.2.s* F=production
+          env: DMD=2.078.3.s* F=production
         - <<: *test-matrix
-          env: DMD=2.071.2.s* F=devel
-        - <<: *test-matrix
-          env: DMD=2.078.* F=production
-        - <<: *test-matrix
-          env: DMD=2.078.* F=devel
+          env: DMD=2.078.3.s* F=devel
         - <<: *test-matrix
           env: DMD=2.088.* F=production
         - <<: *test-matrix
           env: DMD=2.088.* F=devel
+        - <<: *test-matrix
+          env: DIST=bionic DMD=2.092.* F=production
+        - <<: *test-matrix
+          env: DIST=bionic DMD=2.092.* F=devel
+        - <<: *test-matrix
+          env: DIST=bionic DMD=2.093.* F=production
+        - <<: *test-matrix
+          env: DIST=bionic DMD=2.093.* F=devel
 
         # Test deployment docker image generation
         - stage: Test
           script:
-              - docker build --build-arg DMD=2.071.2.s* --build-arg DIST=xenial
+              - docker build --build-arg DMD=2.078.* --build-arg DIST=xenial
                 -t dmqnode .
 
         # Extra sanity checks
         - stage: Closure allocation check
-          env: DMD=2.071.2.s* DIST=xenial F=devel
-          script: beaver dlang install && ci/closures.sh
+          env: DMD=2.078.3.s* F=devel
+          install: beaver dlang install
+          script: ci/closures.sh
 
         # Package matrix
         - <<: *package-matrix
-          env: DMD=2.071.2.s* F=production COV=0
+          env: DMD=2.078.3.s* F=production COV=0

--- a/Build.mak
+++ b/Build.mak
@@ -30,8 +30,8 @@ $O/test-ovfminimize: override DFLAGS += -debug=OvfMinimizeTest -debug=Full
 $O/test-loadfiles: dmqnode
 $O/test-loadfiles: override LDFLAGS += -lpcre
 
-allunittest: override DFLAGS += -debug=OvfMinimizeTest -debug=Full
-allunittest: override LDFLAGS += -lpcre
+$O/%unittests: override DFLAGS += -debug=OvfMinimizeTest -debug=Full
+$O/%unittests: override LDFLAGS += -lpcre
 
 # Additional flags needed when unittesting
 #$O/%unittests: override LDFLAGS +=

--- a/Build.mak
+++ b/Build.mak
@@ -34,7 +34,7 @@ allunittest: override DFLAGS += -debug=OvfMinimizeTest -debug=Full
 allunittest: override LDFLAGS += -lpcre
 
 # Additional flags needed when unittesting
-#$O/%unittests: override LDFLAGS += 
+#$O/%unittests: override LDFLAGS +=
 
 # Package dependencies
 $O/pkg-dmqnode.stamp: $B/dmqnode README.rst \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Duplicate definition of DIST before FROM is needed to be able to use it
 # in docker image name:
 ARG  DIST=xenial
-FROM sociomantictsunami/develdlang:$DIST-v7 as builder
+FROM sociomantictsunami/develdlang:$DIST-v8 as builder
 # Copies the whole project as makd needs git history:
 COPY . /project/
 WORKDIR /project/
@@ -14,7 +14,7 @@ RUN docker/build.sh
 ARG DIST=xenial
 # For now plain ubuntu image is used as base for simplicity. It certainly can be
 # optimized to bare minimum but right now it is not important:
-FROM sociomantictsunami/runtimebase:$DIST-v7
+FROM sociomantictsunami/runtimebase:$DIST-v8
 
 # Set up directories and install the node
 COPY --from=builder /project/build/production/pkg/ /packages/

--- a/ci/closures.sh
+++ b/ci/closures.sh
@@ -1,12 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 set -xe
 
 # Enables printing of all potential GC allocation sources to stdout
 export DFLAGS=-vgc
 
 # Prepare sources
-beaver dlang make d2conv
+beaver dlang make
 
-# Ensure that there are no lines about closure allocations in the output
-# Filters away errors from submodules to focus on swarm own code only
-! beaver dlang make fasttest 2>&1 | grep "\./src/.*\<closure\>"
+# Run tests and write compiler output to temporary file
+compiler_output=`mktemp`
+beaver dlang make fasttest 2>&1 > $compiler_output
+
+# Ensure there are no lines about closure allocations in the output.
+# Note explicit check for `grep` exit status 1, i.e. no lines found.
+! grep -e "closure" $compiler_output

--- a/docker/builder/beaver.Dockerfile
+++ b/docker/builder/beaver.Dockerfile
@@ -1,1 +1,1 @@
-FROM sociomantictsunami/develdlang:v7
+FROM sociomantictsunami/develdlang:v8

--- a/integrationtest/loadfiles/cases/checker/CheckedRequests.d
+++ b/integrationtest/loadfiles/cases/checker/CheckedRequests.d
@@ -247,7 +247,7 @@ class UnexpectedNotification
     ***************************************************************************/
 
     private void setMsg ( cstring type,
-        scope void delegate ( void delegate ( cstring chunk ) sink ) to_string )
+        scope void delegate ( scope void delegate ( cstring chunk ) sink ) to_string )
     {
         auto msg = this.testname;
         msg ~= " - Unexpected notification \"";

--- a/integrationtest/ovfminimize/main.d
+++ b/integrationtest/ovfminimize/main.d
@@ -168,13 +168,12 @@ void run ( )
      */
     void pop ( DiskOverflow.Channel channel )
     {
-        bool popped = channel.pop(
-            delegate void[] (size_t n)
-            {
-                test!("==")(n, pop_result.length);
-                return pop_result;
-            }
-        );
+        scope dg = delegate void[] (size_t n)
+        {
+            test!("==")(n, pop_result.length);
+            return pop_result;
+        };
+        bool popped = channel.pop(dg);
         test(popped);
         test!("==")(pop_result, data);
     }


### PR DESCRIPTION
Remove support for v2.071, bump minimal version to v2.078 and add support for the latest release.