### PR TITLE
Drop compatibility for anything less than v2.092 & xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ git:
 # Global environment variables
 env:
     global:
-        - DIST=xenial
-        - COV=1
+        - DIST=bionic
+        - COV=0
         # Default beaver image names. May be overriden in specific stages
         - BEAVER_DOCKER_IMG=builder
         - BEAVER_DOCKER_CONTEXT=docker/builder
@@ -48,34 +48,26 @@ jobs:
     include:
         # Test matrix
         - <<: *test-matrix
-          env: DMD=2.078.3.s* F=production
-        - <<: *test-matrix
-          env: DMD=2.078.3.s* F=devel
-        - <<: *test-matrix
-          env: DMD=2.088.* F=production
-        - <<: *test-matrix
-          env: DMD=2.088.* F=devel
-        - <<: *test-matrix
           env: DIST=bionic DMD=2.092.* F=production
         - <<: *test-matrix
           env: DIST=bionic DMD=2.092.* F=devel
         - <<: *test-matrix
-          env: DIST=bionic DMD=2.093.* F=production
+          env: DIST=bionic DMD=2.093.* F=production COV=1
         - <<: *test-matrix
-          env: DIST=bionic DMD=2.093.* F=devel
+          env: DIST=bionic DMD=2.093.* F=devel COV=1
 
         # Test deployment docker image generation
         - stage: Test
           script:
-              - docker build --build-arg DMD=2.078.* --build-arg DIST=xenial
+              - docker build --build-arg DMD=2.093.* --build-arg DIST=${DIST}
                 -t dmqnode .
 
         # Extra sanity checks
         - stage: Closure allocation check
-          env: DMD=2.078.3.s* F=devel
+          env: DMD=2.093.* F=devel
           install: beaver dlang install
           script: ci/closures.sh
 
         # Package matrix
         - <<: *package-matrix
-          env: DMD=2.078.3.s* F=production COV=0
+          env: DMD=2.093.* F=production

--- a/Config.mak
+++ b/Config.mak
@@ -1,2 +1,1 @@
-DC := dmd-transitional
 DVER := 2


### PR DESCRIPTION
```
Since we want to drop support for dmd-transitional,
we need to settle on the minimum supported version of DMD.
Due to the various deprecations and some codeggen bugs in -O -inline,
only v2.092.0 and higher is able to compile our code correctly.

Additionally we now only test on bionic instead of xenial,
and reduced coverage to only the latest version of the compiler.
```